### PR TITLE
Fix to create a fake properly that takes a pointer to function returning pointer

### DIFF
--- a/autofff/generator.py
+++ b/autofff/generator.py
@@ -55,7 +55,7 @@ class BareFakeGenerator(FakeGenerator):
             name = utils.create_typedef_name_for_fnc_ptr(decl, param)
 
             type = param.type.type.type
-            while not hasattr(type, 'declname'):
+            while not hasattr(type, "declname"):
                 type = type.type
             type.declname = name
             typedef = Typedef(name, param.quals, ["typedef"], param.type)

--- a/autofff/generator.py
+++ b/autofff/generator.py
@@ -54,7 +54,10 @@ class BareFakeGenerator(FakeGenerator):
         ):
             name = utils.create_typedef_name_for_fnc_ptr(decl, param)
 
-            param.type.type.type.declname = name
+            type = param.type.type.type
+            while not hasattr(type, 'declname'):
+                type = type.type
+            type.declname = name
             typedef = Typedef(name, param.quals, ["typedef"], param.type)
 
             param.type = TypeDecl(

--- a/examples/simple-headers/driver.h
+++ b/examples/simple-headers/driver.h
@@ -36,6 +36,9 @@ void Driver_PowerUp(Config (*config_cb)(void *arg));
 
 void Driver_PowerDown(void);
 
+/* Showcasing in-line function pointer parameters that return pointer */
+void Driver_Register_Callback(void* (*cb)(void *arg));
+
 int Driver_Deinitialize(void);
 
 /* Showcasing inline definition workaround */

--- a/examples/simple-headers/driver.h
+++ b/examples/simple-headers/driver.h
@@ -37,7 +37,7 @@ void Driver_PowerUp(Config (*config_cb)(void *arg));
 void Driver_PowerDown(void);
 
 /* Showcasing in-line function pointer parameters that return pointer */
-void Driver_Register_Callback(void* (*cb)(void *arg));
+void Driver_Register_Callback(void *(*cb)(void *arg));
 
 int Driver_Deinitialize(void);
 


### PR DESCRIPTION
Dear Maintainer,

I have encountered an issue with autofff when creating a fake that takes a pointer to a function returning a pointer. The issue arises because the 'PtrDecl' object does not have a 'declname' attribute.

Here is the error message for reference:

...
  File "/home/sangmo.kang/workspace/autofff/autofff/generator.py", line 56, in _generateTypeDefForDecl
    param.type.type.type.declname = name
AttributeError: 'PtrDecl' object has no attribute 'declname'
...


In response to this, I have attempted to fix the error and have also added a test to ensure its correctness. 
I look forward to your feedback.

Thank you.

