### PR TITLE
Fix to create a fake with a name containing 'asm' properly

### DIFF
--- a/autofff/config.py
+++ b/autofff/config.py
@@ -57,9 +57,7 @@ GCC_SCANNER_CPP_DEFINE_PREFIX = "cpp_define_prefix"
 GCC_SCANNER_CPP_DEFINE_PREFIX_DEF = "-D"
 
 GCC_SCANNER_NON_STANDARD_IGNORE_PATTERN = "non_standard_ignore_pattern"
-GCC_SCANNER_NON_STANDARD_IGNORE_PATTERN_DEF = (
-    r"([\s\n]*(\W(__asm|asm|__asm__)\W)[\s\n]*(volatile|[\s\n]*)(goto|[\s\n]*)(.|\n|;)*?;)"
-)
+GCC_SCANNER_NON_STANDARD_IGNORE_PATTERN_DEF = r"([\s\n]*(\W(__asm|asm|__asm__)\W)[\s\n]*(volatile|[\s\n]*)(goto|[\s\n]*)(.|\n|;)*?;)"
 
 GCC_SCANNER_ERROR_CONTEXT_PREV_LINES = "error_context_prev_lines"
 GCC_SCANNER_ERROR_CONTEXT_PREV_LINES_MIN = 0

--- a/autofff/config.py
+++ b/autofff/config.py
@@ -58,7 +58,7 @@ GCC_SCANNER_CPP_DEFINE_PREFIX_DEF = "-D"
 
 GCC_SCANNER_NON_STANDARD_IGNORE_PATTERN = "non_standard_ignore_pattern"
 GCC_SCANNER_NON_STANDARD_IGNORE_PATTERN_DEF = (
-    r"([\s\n]*(__asm|asm)[\s\n]*(volatile|[\s\n]*)(goto|[\s\n]*)(.|\n|;)*?;)"
+    r"([\s\n]*(\W(__asm|asm|__asm__)\W)[\s\n]*(volatile|[\s\n]*)(goto|[\s\n]*)(.|\n|;)*?;)"
 )
 
 GCC_SCANNER_ERROR_CONTEXT_PREV_LINES = "error_context_prev_lines"

--- a/config.ini
+++ b/config.ini
@@ -34,7 +34,7 @@ cpp_define_prefix="-D"
 # therefore cause compiler errors when autofff tries to parse the preprocessor
 # output. This primarily applies to assembler instructions.
 #   default: "([\s\n]*(__asm|asm)[\s\n]*(volatile|[\s\n]*)(goto|[\s\n]*)(.|\n|;)*?;)"
-non_standard_ignore_pattern="([\s\n]*(__asm|asm)[\s\n]*(volatile|[\s\n]*)(goto|[\s\n]*)(.|\n|;)*?;)"
+non_standard_ignore_pattern="([\s\n]*(\W(__asm|asm|__asm__)\W)[\s\n]*(volatile|[\s\n]*)(goto|[\s\n]*)(.|\n|;)*?;)"
 
 # Number of lines before the faulty line that should be included in the error
 # context if a parsing error occurs.

--- a/examples/simple-headers/driver.h
+++ b/examples/simple-headers/driver.h
@@ -31,6 +31,8 @@ size_t Driver_Write(const uint8_t *buffer, const size_t size);
 /* Showcasing out-parameter pointers */
 void Driver_GrabBuffer(const uint8_t **buffer, size_t *size);
 
+uint16_t Driver_Hasmember(void);
+
 /* Showcasing in-line function pointer parameters */
 void Driver_PowerUp(Config (*config_cb)(void *arg));
 


### PR DESCRIPTION
Dear Maintainer,

I have encountered an issue with autofff when creating a fake with a name containing 'asm'.
Example: `uint16_t Driver_Hasmember();`

In response to this, I have attempted to fix the error and have also added a test to ensure its correctness.
I look forward to your feedback.

Thank you.

